### PR TITLE
Fix typo (missing t in SuperTuxKart)

### DIFF
--- a/_translations/de.po
+++ b/_translations/de.po
@@ -128,7 +128,7 @@ msgid "About the team"
 msgstr "Über das Team"
 
 msgid "About SuperTuxKart"
-msgstr "Über SuperTuxKar"
+msgstr "Über SuperTuxKart"
 
 msgid "Projects using SuperTuxKart"
 msgstr "Projekte mit SuperTuxKart"


### PR DESCRIPTION
Just fixing a little typo.

## Description
"SuperTuxKar" in website footer is supposed to read "SuperTuxKart"
