### PR TITLE
Improve documentation for installing Blender and Subversion

### DIFF
--- a/wiki/Media_Repo.md
+++ b/wiki/Media_Repo.md
@@ -22,9 +22,13 @@ svn checkout https://svn.code.sf.net/p/supertuxkart/code/media/trunk stk-media-r
 
 #### Workaround: Manual download of snapshot 
 
-{%popup_info This workaround is very simple and downloads the same files and folders, but it will not update your files when changes are made to the media repo. This means that if relevant changes are made in the repo after you download the snapshot, your projects may look different in newer versions or possibly even not work properly unless you download a new snapshot.%}
+{% start_liquid popup_info %}
 
-Visit this link to generate a snapshot and download it: https://sourceforge.net/p/supertuxkart/code/HEAD/tarball?path=/media
+This workaround is very simple and downloads the same files and folders, but it will not update your files when changes are made to the media repo. This means that if relevant changes are made in the repo after you download the snapshot, your projects may look different in newer versions or possibly even not work properly unless you download a new snapshot.
+
+{% end_liquid %}
+
+Visit this link to generate a snapshot and download it: <https://sourceforge.net/p/supertuxkart/code/HEAD/tarball?path=/media>
 
 If it asks you to resubmit the snapshot request, do so. Then it will begin a download of the media repo files as they currently are. Extract the ZIP file to a working location where you want your copy of the media repo to be. Now it is ready!
 

--- a/wiki/Media_Repo.md
+++ b/wiki/Media_Repo.md
@@ -6,9 +6,26 @@ The **media repository** is the place where all the original files of 3D Models,
 
 The media repository serves another purpose: using it, you can import a large variety of textures and objects into tracks you make. Because Blender is sensitive about the file structure of your track files when you link textures and library nodes from the media repo, we recommend placing the Blender project file of your kart/track/library node in its own folder under the appropriate category in your downloaded copy of the media repo, **just as if it were an official part of the game.**
 
-We recommend targeting the development version of STK, so the best way to download the media repository is with a Subversion (SVN) client (more information on the [Installing Tools](Installing_Tools) page).
+### Installing the media repo
 
-Under Unix-like operating system, an example checkout command would be:
+We recommend targeting the development version of STK, so the best way to download the media repository is with a Subversion (SVN) client. However, if you cannot get SVN installed, there is a simple workaround.
+
+#### Best way: Installing Subversion
+
+Instructions for installing Subversion are on the [Installing Tools](https://supertuxkart.net/Installing_Tools#subversion-client) page. Once it is installed, use the following address to checkout the repo:
+
+* If you are using a graphical program (e.g. TortoiseSVN), it may ask you for the URL of the repository - `https://svn.code.sf.net/p/supertuxkart/code/media/trunk` - and a checkout directory, which is where on your computer you want it to be copied to.
+* Under Unix-like operating system or MacOS, an example checkout command would be:
 
 {%popup_code
 svn checkout https://svn.code.sf.net/p/supertuxkart/code/media/trunk stk-media-repo%}
+
+#### Workaround: Manual download of snapshot 
+
+{%popup_info This workaround is very simple and downloads the same files and folders, but it will not update your files when changes are made to the media repo. This means that if relevant changes are made in the repo after you download the snapshot, your projects may look different in newer versions or possibly even not work properly unless you download a new snapshot.%}
+
+Visit this link to generate a snapshot and download it: https://sourceforge.net/p/supertuxkart/code/HEAD/tarball?path=/media
+
+If it asks you to resubmit the snapshot request, do so. Then it will begin a download of the media repo files as they currently are. Extract the ZIP file to a working location where you want your copy of the media repo to be. Now it is ready!
+
+Changes are made to the media repo [fairly often](https://sourceforge.net/p/supertuxkart/code/HEAD/log/?path=), so if you want to download a new snapshot, you will have to backup all your projects to another folder, delete your local media repo copy and replace it with a new snapshot.

--- a/wiki_untranslated/Installing_Tools.md
+++ b/wiki_untranslated/Installing_Tools.md
@@ -2,7 +2,7 @@
 title: Installing Tools
 toc: true
 ---
-Welcome! This guide will help you get set up for creating artwork (tracks, karts, textures, etc.) for SuperTuxKart. This guide includes the software you should install and use use, as well as any setup needed. You will have to make decisions in some cases, as there different programs available and you'll have to choose which works best for you.
+Welcome! This guide will help you get set up for creating artwork (tracks, karts, textures, etc.) for SuperTuxKart. This guide includes the software you should install and use, as well as any setup needed. You will have to make decisions in some cases, as there different programs available and you'll have to choose which works best for you.
 
 ## For 2D art creation (textures, posters, etc.)
 
@@ -135,7 +135,7 @@ You can click **Save User Settings** to avoid repeating these steps each time yo
 * **Website:** [subversion.apache.org](https://subversion.apache.org)
 * **License:** Apache License 2.0
 
-A Subversion (more commonly known as SVN) client is a must-have for fetching the latest version of the assets and [media](Media_Repo) repositories. It performs *version control,* a system for recording changes in a collection of files that multiple users access. Mostly it's used by software developers, but we use it to manage artwork resources. We won't go into detail on how to use SVN here (there's plenty of information online), but when you need to use it, we'll provide the URL you'll need to put into your client.
+A Subversion (more commonly known as SVN) client is a must-have for fetching the latest version of the assets and [media repositories](Media_Repo). It performs *version control,* a system for recording changes in a collection of files that multiple users access. Mostly it's used by software developers, but we use it to manage artwork resources. We won't go into detail on how to use SVN here (there's plenty of information online), but when you need to use it, we'll provide the URL you'll need to put into your client.
 
 For Windows users, especially those unfamiliar with the command line, we recommend [TortoiseSVN](https://tortoisesvn.net), an easy-to-use graphical interface for SVN.
 

--- a/wiki_untranslated/Installing_Tools.md
+++ b/wiki_untranslated/Installing_Tools.md
@@ -139,9 +139,11 @@ You can click **Save User Settings** to avoid repeating these steps each time yo
 * **Website:** [subversion.apache.org](https://subversion.apache.org)
 * **License:** Apache License 2.0
 
-A Subversion (more commonly known as SVN) client is a must-have for fetching the latest version of the assets and [media repositories](Media_Repo). It performs *version control,* a system for recording changes in a collection of files that multiple users access. Mostly it's used by software developers, but we use it to manage artwork resources. We won't go into detail on how to use SVN here (there's plenty of information online), but when you need to use it, we'll provide the URL you'll need to put into your client.
+A Subversion (more commonly known as SVN) client is a must-have for fetching the latest version of the assets and [media repositories](Media_Repo). It performs *version control,* a system for recording changes in a collection of files that multiple users access. Mostly it's used by software developers, but we use it to manage artwork resources. We won't go into detail on how to use SVN here (there's plenty of information online for each client), but when you need to use it, we'll provide the URL you'll need to put into your client.
 
-For Windows users, especially those unfamiliar with the command line, we recommend [TortoiseSVN](https://tortoisesvn.net), an easy-to-use graphical interface for SVN.
+* For Windows users, especially those unfamiliar with the command line, we recommend [TortoiseSVN](https://tortoisesvn.net), an easy-to-use graphical interface for SVN. Go to the download page, select the version that matches your machine (in most cases, 64-bit OS) and go through the installation. Once installed, go to the folder in Windows Explorer to where you want your working copy to be, right-click and select `TortoiseSVN` → `Checkout`, then enter the URL of the online repository and make sure the Checkout directory is where you want it to be, then click OK. To update files with changes, select them, then right-click and select `TortoiseSVN` → `Update` in the menu.
+
+* For Mac users, [you can easily install using Homebrew, Fink and MacPorts, among other options](https://subversion.apache.org/packages.html#osx). For Unix-like systems, [you can usually install via command-line](https://subversion.apache.org/packages.html).
 
 ### SuperTuxKart Track Editor
 

--- a/wiki_untranslated/Installing_Tools.md
+++ b/wiki_untranslated/Installing_Tools.md
@@ -62,14 +62,18 @@ The premiere open-source 3D modeling software. Blender has a large and loyal use
 
 Blender must be used for karts and objects, and produces better results than the SuperTuxKart track editor for tracks.
 
+{%popup_info Newest Blender versions may not yet be compatible with the SuperTuxKart Blender scripts. Check the [minimum requirements section](https://github.com/supertuxkart/stk-blender#user-content-supertuxkart-blender-addons) to see which Blender versions are compatible. If necessary, [older Blender versions can be found here](https://www.blender.org/download/lts/).%}
+
 #### Installing SuperTuxKart Blender Scripts
 
-The SuperTuxKart Blender scripts allow you to export your Blender work to the SuperTuxKart formats. Where to get them depends on what Blender version is installed.
+The SuperTuxKart Blender scripts allow you to export your Blender work to the SuperTuxKart formats. Where to get them depends on what Blender version is installed (an older version may be used to open old track files that haven't been upgraded).
 
-* For Blender 2.80 and later: [https://github.com/supertuxkart/stk-blender](https://github.com/supertuxkart/stk-blender)
-* For Blender 2.77, 2.78, and 2.79: [https://sourceforge.net/p/supertuxkart/code/HEAD/tree/media/trunk/blender_26/](https://sourceforge.net/p/supertuxkart/code/HEAD/tree/media/trunk/blender_26/)
-
-You will first need to download everything, including the `stkdata` directory and all the files in it. Once you have downloaded these files and the directory, select all of them and copy them to the clipboard using Ctrl-C or Cmd-C. For Blender 2.80 and later, only the directories `io_antarctica_scene` and `io_scene_spm` need to be copied.
+* For Blender 2.80 and later: 
+    * Go to https://github.com/supertuxkart/stk-blender and download the files. This can be done by clicking the green Code button then selecting 'Download ZIP'.
+    * Open the downloaded ZIP file, select the two folders `io_antarctica_scene` and `io_scene_spm` and copy them to the clipboard using Ctrl-C or Cmd-C.
+* For Blender 2.77, 2.78, and 2.79:
+    * Go to https://sourceforge.net/p/supertuxkart/code/HEAD/tree/media/trunk/blender_26/ and click the Download Snapshot button
+    * Open the downloaded ZIP file, select all the files and the `stkdata` folder, then copy them to the clipboard using Ctrl-C or Cmd-C.
 
 Run Blender once to create configuration directories in your user directory.
 


### PR DESCRIPTION
## Description
These changes add advice on choosing which version of Blender to install and how to install older versions, explains how to download Blender scripts (not intuitive), gives the repo location details for Windows, adds detail on basic TortoiseSVN usage (linking to their documentation is unnecessary), adds basic installation advice for non-Windows users, and explains how to download a snapshot of the media repo while explaining why it isn't recommended to do so. This is done because if an artist can't get version control working, that shouldn't stop them from contributing.
Also contains minor typo fixes.

## Motivation and Context
This change is motivated by reports from multiple artists that the setup instructions were too difficult for non-programmers to understand, resulting in them giving up.
This also aims to reduce the amount of preventable questions asked in the community and to make the setup process for artists less error-prone.

## How Has This Been Tested?
No testing, only markdown edits.