### PR TITLE
Position the header image in the center to see all characters

### DIFF
--- a/_sass/stk-wiki/header.scss
+++ b/_sass/stk-wiki/header.scss
@@ -1,5 +1,6 @@
 .header_wrapper {
     background-image: url('../images/header.jpg');
+    background-position: center;
     position: relative;
     height: 430px;
     background-size: cover;


### PR DESCRIPTION
Depending on available screen area the character on the right might be cropped off.

Before:
![Screenshot 2025-01-20 at 17-58-49 Introduktion](https://github.com/user-attachments/assets/4c3c9547-4985-4083-b7c6-9d6c889297a7)

After:
![Screenshot 2025-01-20 at 17-59-16 Introduktion](https://github.com/user-attachments/assets/182ffcb7-37c5-4d4c-b096-2ef8e309738b)
